### PR TITLE
Fallback Richie enrollment start from course start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix fallback Richie enrollment start from course start
+
 ## [1.1.0] - 2022-01-27
 
 ### Fixed


### PR DESCRIPTION
Enrollment start date should fallback to course start date, by default
Open edX uses the course start date for the enrollment start date when
the enrollment start date isn't defined.
Closes #9
Resolves GN-827