### PR TITLE
Lilac upgrade

### DIFF
--- a/richie_openedx_sync/settings.py
+++ b/richie_openedx_sync/settings.py
@@ -7,3 +7,11 @@ settings.RICHIE_OPENEDX_SYNC_COURSE_HOOKS = getattr(settings, "ENV_TOKENS", {}).
     "RICHIE_OPENEDX_SYNC_COURSE_HOOKS",
     getattr(settings, "RICHIE_OPENEDX_SYNC_COURSE_HOOKS", None),
 )
+
+# Load `RICHIE_OPENEDX_SYNC_LOG_REQUESTS` setting using the open edX `ENV_TOKENS` production mode.
+# This requires the `RICHIE_OPENEDX_SYNC_LOG_REQUESTS` should be added to the `EDXAPP_ENV_EXTRA`
+# ansible deployment configuration.
+settings.RICHIE_OPENEDX_SYNC_LOG_REQUESTS = getattr(settings, "ENV_TOKENS", {}).get(
+    "RICHIE_OPENEDX_SYNC_LOG_REQUESTS",
+    getattr(settings, "RICHIE_OPENEDX_SYNC_LOG_REQUESTS", False),
+)

--- a/richie_openedx_sync/signals.py
+++ b/richie_openedx_sync/signals.py
@@ -4,8 +4,8 @@ Signals reveivers of Richie Open edX synchronization
 from django.dispatch import receiver
 
 from xmodule.modulestore.django import SignalHandler
-from student.signals import ENROLL_STATUS_CHANGE
-from student.models import EnrollStatusChange
+from common.djangoapps.student.signals import ENROLL_STATUS_CHANGE
+from common.djangoapps.student.models import EnrollStatusChange
 
 
 @receiver(

--- a/richie_openedx_sync/tasks.py
+++ b/richie_openedx_sync/tasks.py
@@ -79,6 +79,12 @@ def sync_course_run_information_to_richie(*args, **kwargs) -> Dict[str, bool]:
         log.info(msg)
         return {}
 
+    log_requests = configuration_helpers.get_value_for_org(
+        org,
+        "RICHIE_OPENEDX_SYNC_LOG_REQUESTS",
+        getattr(settings, "RICHIE_OPENEDX_SYNC_LOG_REQUESTS", False),
+    )
+
     result = {}
 
     for hook in hooks:
@@ -101,6 +107,13 @@ def sync_course_run_information_to_richie(*args, **kwargs) -> Dict[str, bool]:
             )
             response.raise_for_status()
             result[richie_url] = True
+            if log_requests:
+                status_code = response.status_code
+                msg = "Synchronized the course {} to richie site {} it returned the HTTP status code {}".format(
+                    course_key, richie_url, status_code
+                )
+                log.info(msg)
+                log.info(response.content)
         except requests.exceptions.HTTPError as e:
             status_code = response.status_code
             msg = "Error synchronizing course {} to richie site {} it returned the HTTP status code {}".format(

--- a/richie_openedx_sync/tasks.py
+++ b/richie_openedx_sync/tasks.py
@@ -9,7 +9,7 @@ from celery import shared_task
 from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from student.models import CourseEnrollment
+from common.djangoapps.student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Refactor Open edX code imports
    Related with the removal of custom config of edx-platform sys.path
    Change code to run on Open edX Lilac and following releases

Add setting that allow to log richie requests