### PR TITLE
fix: increase default timeout and change logging level

### DIFF
--- a/richie_openedx_sync/tasks.py
+++ b/richie_openedx_sync/tasks.py
@@ -95,7 +95,7 @@ def sync_course_run_information_to_richie(*args, **kwargs) -> Dict[str, bool]:
         ).hexdigest()
 
         richie_url = hook.get("url")
-        timeout = int(hook.get("timeout", 5))
+        timeout = int(hook.get("timeout", 20))
 
         try:
             response = requests.post(

--- a/richie_openedx_sync/tasks.py
+++ b/richie_openedx_sync/tasks.py
@@ -119,17 +119,17 @@ def sync_course_run_information_to_richie(*args, **kwargs) -> Dict[str, bool]:
             msg = "Error synchronizing course {} to richie site {} it returned the HTTP status code {}".format(
                 course_key, richie_url, status_code
             )
-            log.error(e, exc_info=True)
-            log.error(msg)
-            log.error(response.content)
+            log.warning(e, exc_info=True)
+            log.warning(msg)
+            log.warning(response.content)
             result[richie_url] = False
 
         except requests.exceptions.RequestException as e:
             msg = "Error synchronizing course {} to richie site {}".format(
                 course_key, richie_url
             )
-            log.error(e, exc_info=True)
-            log.error(msg)
+            log.warning(e, exc_info=True)
+            log.warning(msg)
             result[richie_url] = False
 
     return result


### PR DESCRIPTION
fix: increase default timeout

On some cases the default timeout is too short.
With this change we prevent the timeout error to be
raised and sent by sentry.
relates to #13


feat: change logging level

Change logging integration to Richie from ERROR to
WARNING level.
relates to #13