### PR TITLE
fix: Github Action ubuntu-18.04 runner deprecated and use tagged Github Action for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -30,13 +30,13 @@ jobs:
         --outdir dist/
 
     # - name: Publish distribution 📦 to Test PyPI
-    #   uses: pypa/gh-action-pypi-publish@master
+    #   uses: pypa/gh-action-pypi-publish@v1.8.14
     #   with:
     #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
     #     repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.8.14
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
fix: Github Action ubuntu-18.04 runner deprecated

The `ubuntu-18.04` Github Action runner has been deprecated.
Replaced with `ubuntu-latest`

feat: use tagged Github Action

The `pypa/gh-action-pypi-publish` no longer suggests
to use the `master`, so we are replacing to use the latest tagged version.