### PR TITLE
🔖 bump to version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] - 2024-04-18
+
 ### Changed
 
 - Increase default timeout.

--- a/richie_openedx_sync/__init__.py
+++ b/richie_openedx_sync/__init__.py
@@ -3,6 +3,6 @@ Init for main richie openedx synchronization application
 """
 from __future__ import unicode_literals
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 default_app_config = 'richie_openedx_sync.apps.RichieOpenEdxSyncConfig'


### PR DESCRIPTION
Changed

- Increase default timeout.
- Change logging integration to Richie from ERROR to WARNING level.